### PR TITLE
Integration of the new schema and KTT support

### DIFF
--- a/experiment_files/ktt_coulomb_two_autotuner_versions.json
+++ b/experiment_files/ktt_coulomb_two_autotuner_versions.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0.0",
+	"name": "Random vs. Random KTT 2.1 and KTT 2.2 on Coulomb",
+	"parent_folder": "/home/janka/autotuning_methodology_experiments/test_coulomb_two_versions_KTT",
+	"experimental_groups_defaults": {
+      	"applications": [
+			{
+		    	"name": "coulomb",
+                "input_file" : "/home/janka/KTT/Examples/CoulombSum3d/CoulombSum3dCudaScript.json",
+                "folder": "/home/janka/KTT/Examples/CoulombSum3d"
+            }
+        ],
+        "gpus": ["2080"],
+		"stochastic": true,
+		"repeats": 2,
+		"samples": 1,
+		"minimum_number_of_valid_search_iterations": 5,
+        "ignore_cache": true
+	},
+	"search_strategies": [
+	  {
+		"name": "random-2.1",
+		"search_method": "Random",
+		"display_name": "Random with KTT 2.1",
+        "autotuner": "KTT",
+		"autotuner_path": "/home/janka/KTT/Build/x86_64_Release/"
+	  },
+	  {
+		"name": "random-2.2",
+        "autotuner": "KTT",
+		"autotuner_path": "/home/janka/KTT-2.2/Build/x86_64_Release/",
+		"search_method": "Random",
+		"display_name": "Random with KTT 2.2"
+	  }
+	],
+	"statistics_settings": {
+		"minimization": true,
+		"cutoff_percentile": 0.96,
+		"cutoff_percentile_start": 0.2,
+		"cutoff_type": "fevals",
+		"objective_time_keys": [
+			"all"
+		],
+		"objective_performance_keys": [
+			"TotalDuration"
+		]
+	},	
+	"visualization_settings": {
+		"x_axis_value_types": [
+			"fevals"
+		], 
+		"y_axis_value_types": [
+			"absolute"
+		], 
+		"resolution": 2,
+		"confidence_level": 0.95,
+		"compare_baselines": false,
+		"compare_split_times": false 
+	}
+}

--- a/experiment_files/ktt_coulomb_two_search_methods.json
+++ b/experiment_files/ktt_coulomb_two_search_methods.json
@@ -1,0 +1,69 @@
+{
+    "version": "1.0.0",
+    "name": "Random vs. profbased searcher KTT 2.1 on Coulomb",
+    "parent_folder": "/home/janka/autotuning_methodology_experiments/test_coulomb_two_methods",
+    "experimental_groups_defaults": {
+        "applications": [
+            {
+                "name": "coulomb",
+                "input_file" : "/home/janka/KTT/Examples/CoulombSum3d/CoulombSum3dCudaScript.json",
+                "folder": "/home/janka/KTT/Examples/CoulombSum3d"
+            }
+        ],
+        "gpus": ["2080"],
+        "autotuner": "KTT",
+        "autotuner_path": "/home/janka/KTT/Build/x86_64_Release/",
+        "set_this_to_pythonpath": "/home/janka/KTT/Build/x86_64_Release/:/home/janka/KTT/Scripts",
+        "stochastic": true,
+        "repeats": 2,
+        "samples": 1,
+        "minimum_number_of_valid_search_iterations": 5,
+        "ignore_cache": true
+    },
+    "search_strategies": [
+        {
+            "name": "random",
+            "search_method": "Random",
+            "display_name": "Random"
+        },
+        {
+            "name": "profbased",
+            "search_method": "ProfileBased",
+            "search_method_hyperparameters": [
+                {
+                    "name": "modelPath",
+                    "value": "/home/janka/KTT/Examples/CoulombSum3d/Models/2080-coulomb_output_DT.sav"
+                },
+                {
+                    "name": "batchSize",
+                    "value": "5"
+                }
+            ],
+            "display_name": "Profile-based searcher"
+        }
+    ],
+    "statistics_settings": {
+        "minimization": true,
+        "cutoff_percentile": 0.96,
+        "cutoff_percentile_start": 0.2,
+        "cutoff_type": "fevals",
+        "objective_time_keys": [
+            "all"
+        ],
+        "objective_performance_keys": [
+            "TotalDuration"
+        ]
+    },	
+    "visualization_settings": {
+        "x_axis_value_types": [
+            "fevals"
+        ], 
+        "y_axis_value_types": [
+            "absolute"
+        ], 
+        "resolution": 2,
+        "confidence_level": 0.95,
+        "compare_baselines": false,
+        "compare_split_times": false 
+    }
+}

--- a/experiment_files/ktt_vectorAddition_two_search_methods.json
+++ b/experiment_files/ktt_vectorAddition_two_search_methods.json
@@ -1,0 +1,69 @@
+{
+	"version": "1.0.0",
+	"name": "Random vs. profbased searcher KTT 2.1",
+	"parent_folder": "/home/janka/autotuning_methodology_experiments/test_vectorAddition_two_methods",
+	"experimental_groups_defaults": {
+      	"applications": [
+			{
+		    	"name": "vectorAddition",
+                "input_file" : "/home/janka/KTT/Tutorials/03KernelTuning/KernelTuningCudaScript.json",
+                "folder": "/home/janka/KTT/Tutorials/03KernelTuning/"
+            }
+        ],
+        "gpus": ["2080"],
+        "autotuner": "KTT",
+		"autotuner_path": "/home/janka/KTT/Build/x86_64_Release/",
+        "set_this_to_pythonpath": "/home/janka/KTT/Build/x86_64_Release:/home/janka/KTT/Scripts",
+		"stochastic": true,
+		"repeats": 2,
+		"samples": 1,
+		"minimum_number_of_valid_search_iterations": 2,
+        "ignore_cache": true
+	},
+	"search_strategies": [
+	  {
+		"name": "random",
+		"search_method": "Random",
+		"display_name": "Random"
+	  },
+	  {
+		"name": "profbased",
+		"search_method": "ProfileBased",
+        "search_method_hyperparameters": [
+            {
+                "name": "modelPath",
+                "value": "/home/janka/KTT/Tutorials/03KernelTuning/2080-vectorAdd_output_DT.sav"
+            },
+            {
+                "name": "batchSize",
+                "value": "1"
+            }
+        ],
+		"display_name": "Profile-based searcher"
+	  }
+	],
+	"statistics_settings": {
+		"minimization": true,
+		"cutoff_percentile": 0.96,
+		"cutoff_percentile_start": 0.1,
+		"cutoff_type": "time",
+		"objective_time_keys": [
+			"all"
+		],
+		"objective_performance_keys": [
+			"TotalDuration"
+		]
+	},	
+	"visualization_settings": {
+		"x_axis_value_types": [
+			"fevals"
+		], 
+		"y_axis_value_types": [
+			"absolute"
+		], 
+		"resolution": 2,
+		"confidence_level": 0.95,
+		"compare_baselines": false,
+		"compare_split_times": false 
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "progressbar2 >= 4.2.0",
     "jsonschema >= 4.17.3",
     "nonconformist >= 2.1.0",
-    "kernel_tuner >= 1.0.1",
+    "kernel_tuner >= 1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/autotuning_methodology/caching.py
+++ b/src/autotuning_methodology/caching.py
@@ -30,44 +30,41 @@ class ResultsDescription:
 
     def __init__(
         self,
-        folder_id: str,
-        kernel_name: str,
+        run_folder: Path,
+        application_name: str,
         device_name: str,
-        strategy_name: str,
-        strategy_display_name: str,
+        group_name: str,
+        group_display_name: str,
         stochastic: bool,
         objective_time_keys: list[str],
         objective_performance_keys: list[str],
         minimization: bool,
-        visualization_caches_path: Path,
     ) -> None:
         """Initialization method for the ResultsDescription object.
 
         Args:
-            folder_id: the unique ID of the folder to store in.
-            kernel_name: the name of the kernel used.
+            run_folder: a folder to store all files generated during experiments
+            application_name: the name of the application.
             device_name: the name of the device used.
-            strategy_name: the name of the optimization algorithm used, must not contain spaces or special characters.
-            strategy_display_name: the name of the optimization algorithm used in printing / visualization.
-            stochastic: whether the optimization algorithm is stochastic.
+            group_name: the name of the experimental group, usually search method used, must not contain spaces or special characters.
+            group_display_name: the name of the experimental group used in printing / visualization.
+            stochastic: whether the search method is stochastic.
             objective_time_keys: the objective time keys used.
             objective_performance_keys: the objective performance keys used.
-            minimization: whether the optimization algorithm performed minimization (attempted to find the minimum).
-            visualization_caches_path: path to visualization caches relative to the experiments file, creation allowed.
+            minimization: whether the search method performed minimization (attempted to find the minimum).
         """
         # all attributes must be hashable for symetric difference checking
         self._version = "1.3.0"
         self.__stored = False
-        self.__folder_id = folder_id
-        self.kernel_name = kernel_name
+        self.application_name = application_name
         self.device_name = device_name
-        self.strategy_name = strategy_name
-        self.strategy_display_name = strategy_display_name
+        self.group_name = group_name
+        self.group_display_name = group_display_name
         self.stochastic = stochastic
         self.objective_time_keys = objective_time_keys
         self.objective_performance_keys = objective_performance_keys
         self.minimization = minimization
-        self.visualization_caches_path = visualization_caches_path
+        self.run_folder = run_folder
         self.numpy_arrays_keys = [
             "fevals_results",
             "objective_time_results",
@@ -85,7 +82,7 @@ class ResultsDescription:
             a dictionary, similar to self.__dict__ but with some keys removed.
         """
         dictionary = vars(self)
-        not_saved_keys = ["strategy_display_name", "visualization_caches_path"]
+        not_saved_keys = ["group_display_name", "visualization_caches_path"]
         for not_saved_key in not_saved_keys:
             if not_saved_key in dictionary.keys():
                 del dictionary[not_saved_key]
@@ -124,7 +121,7 @@ class ResultsDescription:
 
         # check if same value for each key
         for attribute_key, attribute_value in self.__get_as_dict().items():
-            if attribute_key == "strategy_display_name" or attribute_key == "visualization_caches_path":
+            if attribute_key == "group_display_name" or attribute_key == "visualization_caches_path":
                 continue
             else:
                 assert (
@@ -134,11 +131,11 @@ class ResultsDescription:
         return True
 
     def __get_cache_filename(self) -> str:
-        return f"{self.device_name}_{self.strategy_name}.npz"
+        return f"{self.device_name}_{self.application_name}.npz"
 
     def __get_cache_filepath(self) -> Path:
         """Get the filepath to this experiment."""
-        return self.visualization_caches_path / self.__folder_id / self.kernel_name
+        return self.run_folder
 
     def __get_cache_full_filepath(self) -> Path:
         """Get the filepath for this file, including the filename and extension."""

--- a/src/autotuning_methodology/curves.py
+++ b/src/autotuning_methodology/curves.py
@@ -230,10 +230,10 @@ class Curve(CurveBasis):
             results_description: the ResultsDescription object containing the data for the Curve.
         """
         # inputs
-        self.name = results_description.strategy_name
-        self.display_name = results_description.strategy_display_name
+        self.name = results_description.group_name
+        self.display_name = results_description.group_display_name
         self.device_name = results_description.device_name
-        self.kernel_name = results_description.kernel_name
+        self.application_name = results_description.application_name
         self.stochastic = results_description.stochastic
         self.minimization = results_description.minimization
 
@@ -265,7 +265,7 @@ class Curve(CurveBasis):
         assert isinstance(self.name, str)
         assert isinstance(self.display_name, str)
         assert isinstance(self.device_name, str)
-        assert isinstance(self.kernel_name, str)
+        assert isinstance(self.application_name, str)
         assert isinstance(self.stochastic, bool)
         assert isinstance(self._x_fevals, np.ndarray)
         assert isinstance(self._x_time, np.ndarray)

--- a/src/autotuning_methodology/experiments.py
+++ b/src/autotuning_methodology/experiments.py
@@ -3,18 +3,18 @@
 from __future__ import annotations  # for correct nested type hints e.g. list[str], tuple[dict, str]
 
 import json
-import sys
 from argparse import ArgumentParser
-from importlib import import_module
 from importlib.resources import files
 from math import ceil
 from os import getcwd
+from os import makedirs
 from pathlib import Path
 
 from jsonschema import validate
 
 from autotuning_methodology.caching import ResultsDescription
 from autotuning_methodology.runner import collect_results
+from autotuning_methodology.runner import convert_KTT_output_to_standard
 from autotuning_methodology.searchspace_statistics import SearchspaceStatistics
 
 
@@ -30,13 +30,16 @@ def get_args_from_cli(args=None) -> str:
     Returns:
         The filepath to the experiments file.
     """
-    CLI = ArgumentParser()
-    CLI.add_argument("experiment", type=str, help="The experiment.json to execute, see experiments/template.json")
-    args = CLI.parse_args(args)
+    cli = ArgumentParser()
+    cli.add_argument(
+        "experiment", type=str,
+        help="The experiment setup json file to execute, see experiments/template.json"
+    )
+    args = cli.parse_args(args)
     filepath: str = args.experiment
     if filepath is None or filepath == "":
         raise ValueError(
-            "Invalid '-experiment' option. Run 'visualize_experiments.py -h' to read more about the options."
+            "Invalid '--experiment' option. Run 'visualize_experiments.py -h' to read more."
         )
     return filepath
 
@@ -50,6 +53,24 @@ def get_experiment_schema_filepath():
     schemafile = files("autotuning_methodology").joinpath("schema.json")
     assert schemafile.is_file(), f"Path to schema.json does not exist, attempted path: {schemafile}"
     return schemafile
+
+def make_and_check_path(filename: str, parent = None, extension = None) -> Path:
+    filename_path = Path(filename)
+    if filename_path.is_absolute() is False and parent is not None:
+        filename_path = Path(parent).joinpath(filename).resolve()
+    if filename_path.exists():
+        return filename_path
+    # try and add extension
+    if extension is None:
+        raise FileNotFoundError(
+            f"{filename_path} does not exist."
+        )
+    filename_path = Path(str(filename_path) + extension)
+    if filename_path.exists():
+        return filename_path
+    raise FileNotFoundError(
+        f"{filename_path} does not exist."
+    )
 
 
 def get_experiment(filename: str) -> dict:
@@ -84,37 +105,285 @@ def get_experiment(filename: str) -> dict:
         return experiment
 
 
-def get_strategies(experiment: dict) -> dict:
-    """Gets the strategies from an experiments file by augmenting it with the defaults.
+def get_experimental_groups(experiment: dict) -> list[dict]:
+    """Prepares all the experimental groups as all combinations of application and gpus (from experimental_groups_defaults) and big experimental groups from setup file (experimental_groups, usually search methods). Check additional settings for each experimental group. Prepares the directory structure for the whole experiment.
 
     Args:
         experiment: the experiment dictionary object.
 
     Returns:
-        The strategies in the experiment dictionary object, augmented where necessery.
+        The experimental groups in the experiment dictionary object.
     """
-    strategy_defaults = experiment["strategy_defaults"]
-    strategies = experiment["strategies"]
-    # # get a baseline index if it exists
-    # baseline_index = list(
-    #     strategy_index for strategy_index, strategy in enumerate(strategies) if "is_baseline" in strategy
-    # )
-    # if len(baseline_index) != 1:
-    #     raise ValueError(f"There must be exactly one baseline, found {len(baseline_index)} baselines")
-    # if strategies[baseline_index[0]]["is_baseline"] is not True:
-    #     raise ValueError(f"is_baseline must be true, yet is set to {strategies[0]['is_baseline']}!")
-    # # if the baseline index is not 0, put the baseline strategy first
-    # if baseline_index[0] != 0:
-    #     raise ValueError("The baseline strategy must be the first strategy in the experiments file!")
-    #     # strategies.insert(0, strategies.pop(baseline_index[0]))
+    experimental_groups_defaults = experiment["experimental_groups_defaults"]
+    search_strategies = experiment["search_strategies"]
 
-    # augment the strategies with the defaults
-    for strategy in strategies:
-        for default in strategy_defaults:
-            if default not in strategy:
-                strategy[default] = strategy_defaults[default]
-    return strategies
+    # set up the directory structure
+    experiment["parent_folder_absolute_path"] = Path(experiment["parent_folder"]).resolve()
+    # if folder "run" does not exist, create
+    makedirs(experiment["parent_folder_absolute_path"].joinpath("run"), exist_ok = True)
+    makedirs(experiment["parent_folder_absolute_path"].joinpath("setup"), exist_ok = True)
 
+    # create folders for each experimental group from file
+    for strategy in search_strategies:
+        makedirs(experiment["parent_folder_absolute_path"].joinpath("run").joinpath(strategy["name"]), exist_ok = True)
+
+    # generate all experimental groups
+    # with applications and gpus provided in experimental_groups_defaults
+    # and search strategies provided in search_strategies
+    all_experimental_groups = generate_all_experimental_groups(
+        search_strategies,
+        experimental_groups_defaults,
+        experiment["parent_folder_absolute_path"]
+    )
+
+    # additional check beyond validation
+        # if every experimental group has autotuner set
+        # set autotuner_path to default installation if not set by the user
+    for group in all_experimental_groups:
+        if group.get("autotuner") is None:
+            raise KeyError(
+                "Property 'autotuner' must be set for all groups, either in experimental_groups_defaults or in experimental_groups. It is not set for",
+                group["full_name"]
+            )
+        if group["autotuner"] == "KTT":
+            if group["samples"] != 1:
+                raise NotImplementedError(
+                    f"KTT currently supports only one sample per run and output. Please set samples=1 for group['full_name']."
+                )
+            if group.get("autotuner_path") is None:
+                raise NotImplementedError(
+                    "Default autotuner_path is not supported yet for KTT, please set autotuner_path for ", group["full_name"] + " to directory with KttTuningLauncher and pyktt.so, e.g. /home/user/KTT/Build/x86_64_Release."
+                )
+            elif Path(group["autotuner_path"]).exists() is False:
+                raise FileNotFoundError(
+                    f"Directory {group['autotuner_path']} does not exists. Try setting the absolute path."
+                )
+            elif Path(group["autotuner_path"]).joinpath("KttTuningLauncher").exists() is False:
+                raise FileNotFoundError(
+                    f"Directory {group['autotuner_path']} does not contain KttTuningLauncher. Have you used --tuning-loader when premaking KTT?"
+                )
+            elif Path(group["autotuner_path"]).joinpath("pyktt.so").exists() is False:
+                raise FileNotFoundError(
+                    f"Directory {group['autotuner_path']} does not contain pyktt.so. Have you used --python when premaking KTT?"
+                )
+            # TODO make and set default autotuner path
+
+    return all_experimental_groups
+
+def generate_all_experimental_groups(
+    search_strategies: list[dict],
+    experimental_groups_defaults: dict,
+    parent_folder_path: Path
+) -> list[dict]:
+    """Generates all experimental groups for the experiment as a combination of given applications, gpus and search strategies from experiments setup file.
+
+    Args:
+        search_strategies: list of dictionaries with settings for various search strategies from experiments setup file, section search_strategies.
+        experimental_groups_defaults: a dictionary with default settings for experimental groups from experiments setup file, section experimental_groups_defaults.
+        parent_folder_path: path to experiment parent folder that stores all files generated in the experiment.
+
+    Returns:
+        A list of dictionaries, one for each experimental group.
+    """
+    experimental_groups = []
+
+    for gpu in experimental_groups_defaults["gpus"]:
+        for application in experimental_groups_defaults["applications"]:
+            for strategy in search_strategies:
+                group = strategy
+
+                for default in experimental_groups_defaults:
+                    if default not in group and default not in [
+                        "applications", "gpus", "pattern_for_full_search_space_filenames"
+                    ]:
+                        group[default] = experimental_groups_defaults[default]
+
+                group["full_name"] = "_".join([gpu, application["name"], group["name"]])
+
+                group["gpu"] = gpu
+                group["application_name"] = application["name"]
+
+                group["application_folder"] = Path(application["folder"])
+                group["application_input_file"] = make_and_check_path(application["input_file"], application["folder"], None)
+                group["input_file"] : Path
+                group["input_file"] = parent_folder_path.joinpath("setup").joinpath(
+                        "_".join([group["full_name"], "input.json"]))
+
+                if experimental_groups_defaults.get("pattern_for_full_search_space_filename") is None:
+                    group["full_search_space_file"] = get_full_search_space_filename_from_input_file(
+                        group["application_input_file"]
+                    )
+                else:
+                    group["full_search_space_file"] = get_full_search_space_filename_from_pattern(
+                        experimental_groups_defaults["pattern_for_full_search_space_filenames"],
+                        gpu,
+                        application["name"]
+                    )
+
+                if group["autotuner"] == "KTT":
+                    # convert full search space file from KTT output format to standard format
+                    # note that full search space file in KTT output format still gets injected to input json, that is because KTT needs to have that file in its own format
+                    # the converted file is loaded with this package when calculating search space statistics
+                    group["converted_full_search_space_file"] = convert_KTT_to_standard_full_search_space_file(
+                        group["full_search_space_file"],
+                        parent_folder_path.joinpath("setup")
+                    )
+
+                group["output_file"] : Path
+                group["output_file"] = parent_folder_path.joinpath("run").joinpath(
+                    group["name"]).joinpath(group["full_name"] + ".json").resolve()
+
+
+                generate_input_file(group)
+                experimental_groups.append(group)
+
+    return experimental_groups
+
+
+def get_full_search_space_filename_from_input_file(input_filename: Path) -> Path:
+    """Returns a path to full search space file that is provided in the input json file in KernelSpecification.SimulationInput.
+
+    Args:
+        input_filename: path to input json file.
+
+    Raises:
+        KeyError: if the path is not provided, but is expected.
+
+    Returns:
+        A path to full search space file that was written in the input json file.
+    """
+    with open(input_filename, 'r', encoding="utf-8") as input_file:
+        input_json = json.load(input_file)
+        if input_json["KernelSpecification"].get("SimulationInput") is None:
+            raise KeyError(
+                "SimulationInput, i.e. full search space file is expected and not defined in", input_filename, ". Please set the path to that file in KernelSpecification.SimulationInput in input json file or set pattern_for_full_search_space_filename in experiments setup json file.")
+        full_search_space_filename = make_and_check_path(input_json["KernelSpecification"]["SimulationInput"], str(input_filename.parent), ".json")
+    # need to return filename WITHOUT .json, KTT (and probably also others) needs that in SimulationInput in input json as other autotuner can take other formats
+    return full_search_space_filename.parent.joinpath(full_search_space_filename.stem)
+
+def get_full_search_space_filename_from_pattern(
+    pattern: dict, gpu: str, application_name: str
+) -> Path:
+    """Returns a path to full search space file that is generated from the pattern provided in experiments setup file.
+
+    Args:
+        pattern: pattern regex string
+        gpu: name of the gpu, needs to be plugged into the pattern
+        application_name: name of the application, needs to be plugged into the pattern
+
+    Raises:
+        NotImplementedError: if the regex expects other variables than just application name and gpu.
+
+    Returns:
+        A path to full search file generated from the pattern.
+    """
+    if pattern["regex_variables"] != ["applications", "gpus"]:
+        raise NotImplementedError("Other variables than applications and gpus in pattern for full search space filename are not supported yet. Sorry.")
+    filename = pattern["regex"].replace("${applications}", application_name).replace("${gpus}", gpu)
+    full_search_space_filename = make_and_check_path(filename)
+    return full_search_space_filename
+
+def convert_KTT_to_standard_full_search_space_file(
+        full_search_space_file: Path,
+        setup_folder: Path) -> Path:
+    """ Converts KTT-formatted full search space file to the standard format recognized by this package.
+
+    Args:
+        full_search_space_file: the path to KTT-formatted full search space file
+        setup_folder: path to setup directory for this experiment
+
+    Returns:
+        A path to newly created full search space file in standard format, in the setup directory of the experiment
+    """
+    converted_output = convert_KTT_output_to_standard(full_search_space_file.with_suffix(".json"))
+    converted_filename = setup_folder.joinpath(full_search_space_file.stem + "_converted.json")
+
+    with open(converted_filename, "w", encoding = "utf-8") as converted_file:
+        json.dump(converted_output, converted_file, indent=4)
+
+    return converted_filename
+
+
+def calculate_budget(
+    group: dict, statistics_settings: dict, searchspace_stats: SearchspaceStatistics
+) -> dict:
+    """Calculates the budget for the experimental group, given cutoff point provided in experiments setup file.
+
+    Args:
+        group: a dictionary with settings for experimental group
+        statistics_settings: a dictionary with settings related to statistics
+        searchspace_stats: a SearchspaceStatistics instance with cutoff points determined from related full search space files
+
+    Returns:
+        A modified group dictionary.
+    """
+    group["budget"] = {}
+    # set cutoff point
+    _, cutoff_point_fevals, cutoff_point_time = searchspace_stats.cutoff_point_fevals_time(
+        statistics_settings["cutoff_percentile"]
+    )
+
+    # +10% margin, to make sure cutoff_point is reached by compensating for potential non-valid evaluations  # noqa: E501
+    cutoff_margin = group.get("cutoff_margin", 1.1)
+
+    # set when to stop
+    if statistics_settings["cutoff_type"] == "time":
+        group["budget"]["time_limit"] = cutoff_point_time * cutoff_margin
+    else:
+        group["budget"]["max_fevals"] = min(
+                int(ceil(cutoff_point_fevals * cutoff_margin)), searchspace_stats.size
+                )
+
+    # write to group's input file as Budget
+    with open(group["input_file"], "r", encoding="utf-8") as fp:
+        input_json = json.load(fp)
+        if input_json.get("Budget") is None:
+            input_json["Budget"] = []
+            input_json["Budget"].append({})
+        if group["budget"].get("time_limit") is not None:
+            input_json["Budget"][0]["Type"] = "TuningDuration"
+            input_json["Budget"][0]["BudgetValue"] = group["budget"]["time_limit"]
+        else: #it's max_fevals
+            input_json["Budget"][0]["Type"] = "ConfigurationCount"
+            input_json["Budget"][0]["BudgetValue"] = group["budget"]["max_fevals"]
+
+    with open(group["input_file"], "w", encoding="utf-8") as fp:
+        json.dump(input_json, fp, indent=4)
+
+    return group
+
+def generate_input_file(group: dict):
+    """Creates a input json file specific for a given application, gpu and search method.
+
+    Args:
+        group: dictionary with settings for a given experimental group.
+    """
+    with open(group["application_input_file"], "r", encoding="utf-8") as fp:
+        input_json = json.load(fp)
+        input_json["KernelSpecification"]["SimulationInput"] = str(group["full_search_space_file"])
+        input_json["General"]["OutputFile"] = str(
+            group["output_file"].parent.joinpath(group["output_file"].stem)
+        )
+        if input_json["General"]["OutputFormat"] != "JSON":
+            raise RuntimeError(f"Only JSON output format is supported. Please set General.OutputFormat to JSON in {group['application_input_file']}.")
+        if input_json["KernelSpecification"].get("Device") is None:
+            input_json["KernelSpecification"]["Device"] = {}
+            input_json["KernelSpecification"]["Device"]["Name"] = group["gpu"]
+        else:
+            input_json["KernelSpecification"]["Device"]["Name"] = group["gpu"]
+
+        input_json["Search"] = {}
+        input_json["Search"]["Name"] = group["search_method"]
+        if group.get("search_method_hyperparameters") is not None:
+            input_json["Search"]["Attributes"] = []
+            for param in group["search_method_hyperparameters"]:
+                attribute = {}
+                attribute["Name"] = param["name"]
+                attribute["Value"] = param["value"]
+                input_json["Search"]["Attributes"].append(attribute)
+    # note that this is written to a different file, specific for gpu, application and search method
+    with open(group["input_file"], "w", encoding="utf-8") as fp:
+        json.dump(input_json, fp, indent=4)
 
 def execute_experiment(filepath: str, profiling: bool = False) -> tuple[dict, dict, dict]:
     """Executes the experiment by retrieving it from the cache or running it.
@@ -127,100 +396,104 @@ def execute_experiment(filepath: str, profiling: bool = False) -> tuple[dict, di
         FileNotFoundError: if the path to the kernel specified in the experiments file is not found.
 
     Returns:
-        A tuple of the experiment dictionary, the strategies executed, and the resulting list of ``ResultsDescription``.
+        A tuple of the experiment dictionary, the experimental groups executed, and the resulting list of ``ResultsDescription``.
     """
     experiment = get_experiment(filepath)
-    experiment_folderpath = Path(filepath).parent
+    experiment_folderpath = Path(experiment["parent_folder"])
     print(f"Starting experiment '{experiment['name']}'")
-    experiment_folder_id: str = experiment["folder_id"]
-    minimization: bool = experiment.get("minimization", True)
-    cutoff_percentile: float = experiment.get("cutoff_percentile", 1)
-    cutoff_type: str = experiment.get("cutoff_type", "fevals")
-    assert cutoff_type == "fevals" or cutoff_type == "time", f"cutoff_type must be 'fevals' or 'time', is {cutoff_type}"
-    curve_segment_factor: float = experiment.get("curve_segment_factor", 0.05)
-    assert isinstance(curve_segment_factor, float), f"curve_segment_factor is not float, {type(curve_segment_factor)}"
-    strategies: list[dict] = get_strategies(experiment)
 
-    # add the kernel directory to the path to import the module, relative to the experiment file
-    kernels_path = experiment_folderpath / Path(experiment["kernels_path"])
-    if not kernels_path.exists():
-        raise FileNotFoundError(f"No such path {kernels_path.resolve()}, CWD: {getcwd()}")
-    sys.path.append(str(kernels_path))
-    kernel_names = experiment["kernels"]
-    kernels = list(import_module(kernel_name) for kernel_name in kernel_names)
+    all_experimental_groups = get_experimental_groups(experiment)
 
-    # variables for comparison
-    objective_time_keys: list[str] = experiment["objective_time_keys"]
-    objective_performance_keys: list[str] = experiment["objective_performance_keys"]
+    # prepare objective_time_keys, in case it was defined as all, explicitly list all keys
+    objective_time_keys: list[str] = experiment["statistics_settings"]["objective_time_keys"]
+    if "all" in objective_time_keys:
+        objective_time_keys = []
+        # get the path to the schema
+        schemafile = get_experiment_schema_filepath()
+        # open the experiment file and validate using the schema file
+        with open(schemafile, "r", encoding="utf-8") as schemafile:
+            schema = json.load(schemafile)
+            objective_time_keys = schema["properties"]["statistics_settings"]["properties"]["objective_time_keys"]["items"]["enum"]
+        objective_time_keys.remove("all")
+        experiment["statistics_settings"]["objective_time_keys"] = objective_time_keys
 
-    # execute each strategy in the experiment per GPU and kernel
-    results_descriptions: dict[str, dict[str, dict[str, ResultsDescription]]] = dict()
-    gpu_name: str
-    for gpu_name in experiment["GPUs"]:
-        print(f" | running on GPU '{gpu_name}'")
-        results_descriptions[gpu_name] = dict()
-        for index, kernel in enumerate(kernels):
-            kernel_name = kernel_names[index]
-            searchspace_stats = SearchspaceStatistics(
-                kernel_name=kernel_name,
-                device_name=gpu_name,
-                minimization=minimization,
-                objective_time_keys=objective_time_keys,
-                objective_performance_keys=objective_performance_keys,
-                bruteforced_caches_path=experiment_folderpath / experiment["bruteforced_caches_path"],
-            )
+    experiment["experimental_groups_defaults"]["applications_names"] = []
+    for application in experiment["experimental_groups_defaults"]["applications"]:
+        experiment["experimental_groups_defaults"]["applications_names"].append(application["name"])
 
-            # set cutoff point
-            _, cutoff_point_fevals, cutoff_point_time = searchspace_stats.cutoff_point_fevals_time(cutoff_percentile)
+    # initialize the matrix of results_descriptions based on provided gpus and applications
+    # initialize searchspace statistics, one for each full search file
+    results_descriptions: dict[str, dict[str, dict[str, ResultsDescription]]] = {}
+    searchspace_statistics: dict[str, dict[str, SearchspaceStatistics]] = {}
 
-            print(f" | - optimizing kernel '{kernel_name}'")
-            results_descriptions[gpu_name][kernel_name] = dict()
-            for strategy in strategies:
-                strategy_name: str = strategy["name"]
-                strategy_display_name: str = strategy["display_name"]
-                stochastic = strategy["stochastic"]
-                cutoff_margin = strategy.get(
-                    "cutoff_margin", 1.1
-                )  # +10% margin, to make sure cutoff_point is reached by compensating for potential non-valid evaluations  # noqa: E501
-                print(f" | - | using strategy '{strategy['display_name']}'")
+    for gpu in experiment["experimental_groups_defaults"]["gpus"]:
+        results_descriptions[gpu] = {}
+        searchspace_statistics[gpu] = {}
+        for application in experiment["experimental_groups_defaults"]["applications_names"]:
+            results_descriptions[gpu][application] = {}
 
-                # setup the results description
-                if "options" not in strategy:
-                    strategy["options"] = dict()
 
-                # set when to stop
-                if cutoff_type == "time":
-                    strategy["options"]["time_limit"] = cutoff_point_time * cutoff_margin
-                else:
-                    strategy["options"]["max_fevals"] = min(
-                        int(ceil(cutoff_point_fevals * cutoff_margin)), searchspace_stats.size
-                    )
-                results_description = ResultsDescription(
-                    experiment_folder_id,
-                    kernel_name,
-                    gpu_name,
-                    strategy_name,
-                    strategy_display_name,
-                    stochastic,
-                    objective_time_keys=objective_time_keys,
-                    objective_performance_keys=objective_performance_keys,
-                    minimization=minimization,
-                    visualization_caches_path=experiment_folderpath / experiment["visualization_caches_path"],
+
+# just iterate over experimental_groups, collect results and write to proper place
+    for group in all_experimental_groups:
+
+        print(f" | - running on GPU '{group['gpu']}'")
+        print(f" | - | tuning application '{group['application_name']}'")
+        print(f" | - | - | with settings of experimental group '{group['display_name']}'")
+
+        # create SearchspaceStatistics for full search space file associated with this group, if it does not exist
+        if searchspace_statistics.get(group["gpu"]).get(group["application_name"]) is None:
+            full_search_space_file_path = None
+            if group.get("converted_full_search_space_file") is None:
+                full_search_space_file_path = group["full_search_space_file"]
+            else:
+                full_search_space_file_path = group["converted_full_search_space_file"]
+
+            searchspace_statistics[group["gpu"]][group["application_name"]] = SearchspaceStatistics(
+                application_name = group["application_name"],
+                device_name = group["gpu"],
+                minimization = experiment["statistics_settings"]["minimization"],
+                objective_time_keys = objective_time_keys,
+                objective_performance_keys = experiment["statistics_settings"]["objective_performance_keys"],
+                full_search_space_file_path = full_search_space_file_path,
                 )
 
-                # if the strategy is in the cache, use cached data
-                if "ignore_cache" not in strategy and results_description.has_results():
-                    print(" | - |-> retrieved from cache")
-                else:  # execute each strategy that is not in the cache
-                    results_description = collect_results(
-                        kernel, strategy, results_description, searchspace_stats, profiling=profiling
-                    )
+        # calculation of budget can be done only now, after searchspace statistics have been initialized
+        group = calculate_budget(
+            group,
+            experiment["statistics_settings"],
+            searchspace_statistics[group["gpu"]][group["application_name"]]
+        )
 
-                # set the results
-                results_descriptions[gpu_name][kernel_name][strategy_name] = results_description
+        results_description = ResultsDescription(
+            run_folder = experiment_folderpath/ "run" / group["name"],
+            application_name = group["application_name"],
+            device_name = group["gpu"],
+            group_name = group["name"],
+            group_display_name = group["display_name"],
+            stochastic = group["stochastic"],
+            objective_time_keys = objective_time_keys,
+            objective_performance_keys = experiment["statistics_settings"]["objective_performance_keys"],
+            minimization = experiment["statistics_settings"]["minimization"],
+        )
 
-    return experiment, strategies, results_descriptions
 
+        # if the strategy is in the cache, use cached data
+        if ("ignore_cache" not in group or group["ignore_cache"] is False) and results_description.has_results():
+            print(" | - | - | -> retrieved from cache")
+        else:  # execute each strategy that is not in the cache
+            results_description = collect_results(
+                group["input_file"],
+                group,
+                results_description,
+                searchspace_statistics[group["gpu"]][group["application_name"]],
+                profiling=profiling
+            )
+
+        # set the results
+        results_descriptions[group["gpu"]][group["application_name"]][group["name"]] = results_description
+
+    return experiment, all_experimental_groups, searchspace_statistics, results_descriptions
 
 def entry_point():  #  pragma: no cover
     """Entry point function for Experiments."""

--- a/src/autotuning_methodology/schema.json
+++ b/src/autotuning_methodology/schema.json
@@ -1,88 +1,295 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/schemas/experiments/v0.1.1.schema.json",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "title": "Experiment",
-  "description": "An experiment configuration file",
+  "description": "An experiment setup configuration file",
   "type": "object",
+  "required": [
+    "name",
+    "parent_folder",
+    "experimental_groups_defaults",
+    "search_strategies",
+    "statistics_settings",
+    "visualization_settings"
+  ],
   "properties": {
     "version": {
-      "description": "Version number of the experiment file standard",
+      "description": "Version number of the experiment setup configuration file standard",
       "type": "string"
     },
     "name": {
       "description": "Name of the experiment",
       "type": "string"
     },
-    "folder_id": {
-      "description": "Unique ID of the folder to store the results of this experiment in",
-      "type": "string"
-    },
-    "kernels_path": {
-      "description": "Path to the directory that has the tuning scripts specified in `kernels`, relative to the experiments file.",
-      "type": "string"
-    },
-    "bruteforced_caches_path": {
-      "description": "Path to the directory that has the bruteforced caches, relative to the experiments file.",
-      "type": "string"
-    },
-    "visualization_caches_path": {
-      "description": "Path to the directory to write / look for visualization caches, relative to the experiments file.",
-      "type": "string"
-    },
-    "kernels": {
-      "description": "Kernels to optimize",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "GPUs": {
-      "description": "GPUs to optimize on",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "minimization": {
-      "description": "Direction of optimization (minimize or maximize)",
-      "type": "boolean",
-      "default": true
-    },
-    "resolution": {
-      "description": "The resolution of the time range",
-      "type": "integer",
-      "minimum": 2
-    },
-    "cutoff_percentile": {
-      "description": "Fraction of difference between median and absolute optimum at which to stop the time range",
-      "type": "number",
-      "exclusiveMinimum": 0,
-      "maximum": 1
-    },
-    "cutoff_percentile_start": {
-      "description": "Fraction of difference between median and absolute optimum at which to start the time range",
-      "type": "number",
-      "minimum": 0,
-      "exclusiveMaximum": 1
-    },
-    "cutoff_type": {
-      "description": "Whether to base the cutoff on function evaluations or time",
+    "parent folder": {
+      "description": "Absolute or relative path of the folder to store all related files for this experiment. This folder needs to already exist.",
       "type": "string",
-      "enum": [
-        "fevals",
-        "time"
-      ]
+      "default": "./"
     },
-    "plot": {
+    "experimental_groups_defaults": {
+      "description": "Default settings for experimental groups",
       "type": "object",
+      "required": [
+        "applications",
+        "gpus"
+      ],
       "properties": {
-        "plot_x_value_types": {
-          "description": "Types of value on the x-axis",
+        "autotuner": {
+          "description": "Autotuner that will be used to tune the experimental group. Has to be specified either in experimental_groups_defaults or in experimental group.",
+          "enum": [
+            "KernelTuner",
+            "KTT"
+          ]
+        },
+        "autotuner_path": {
+          "description": "Path to the library of the autotuner",
+          "type": "string"
+        },
+        "applications": {
+          "description": "List of applications for which measurements were taken and written to full search space files. Can be used in pattern_for_full_search_space_filename.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "input_file"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "input_file": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "gpus": {
+          "description": "List of GPUs where measurements were taken and written to full search space files. Can be used in pattern_for_full_search_space_filename.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pattern_for_full_search_space_filenames": {
+          "description": "Pattern for filenames of full search space files",
+          "type": "object",
+          "required": [
+            "regex",
+            "regex_variables"
+          ],
+          "properties": {
+            "regex": {
+              "type": "string",
+              "pattern": "(.*\\${gpus}.*\\${applications}.*\\.json)|(.*\\${kernel}.*\\${gpu}.*\\.json)",
+              "examples": [
+                "${gpus}_${applications}_output.json",
+                "full-search-space-${applications}-${gpus}.json"
+              ]     
+            },
+            "regex_variables": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": ["applications", "gpus"]
+            }           
+          } 
+        },
+        "stochastic": {
+          "description": "Whether the repeated runs of the same experimental group (combination of application, GPU and search strategy) exhibit stochastic behaviour, e.g. due to stochastic search strategy",
+          "type": "boolean",
+          "default": true
+        },
+        "repeats": {
+          "description": "How many times to repeat the run for a single experimental group (combination of application, GPU and search strategy)",
+          "type": "integer",
+          "minimum": 1,
+          "default": 100
+        },
+        "samples": {
+          "description": "How many samples of measurements for a single configuration are present in full search space file",
+          "type": "integer",
+          "minimum": 1,
+          "default": 32
+        },
+        "minimum_number_of_valid_search_iterations": {
+          "description": "How many non-error, valid configurations account for a single run of search algorithm",
+          "type": "integer",
+          "minimum": 1,
+          "default": 20
+        },
+        "ignore_cache": {
+          "description": "If true, always re-run the experiments, even though results from previously executed experiments are stored in run folder.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "search_strategies": {
+      "description": "Settings for search strategies",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "search_method",
+          "display_name"
+        ],
+        "properties": {
+          "name": {
+            "description": "Name of the search strategy",
+            "type": "string"
+          },
+          "autotuner": {
+            "description": "Autotuner that will be used for tuning. Has to be specified either in experimental_groups_defaults or in search_strategies.",
+            "enum": [
+              "KernelTuner",
+              "KTT"
+            ]
+          },
+          "autotuner_path": {
+            "description": "Path to the library of the autotuner",
+            "type": "string"
+          },
+          "search_method": {
+            "description": "Name of the search method as recognized by the autotuner",
+            "type": "string"
+          },
+          "search_method_hyperparameters": {
+            "description": "A list of hyperparameters for the search method as recognized by the autotuner",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "display_name": {
+            "description": "Name for the search strategy used in visualizations",
+            "type": "string"
+          },
+          "stochastic": {
+            "description": "Whether the repeated runs of the same experimental group (combination of application, GPU and search strategy) exhibit stochastic behaviour, e.g. due to stochastic search strategy",
+            "type": "boolean",
+            "default": true
+          },
+          "repeats": {
+            "description": "How many times to repeat the run for a single experimental group (combination of application, GPU and search strategy)",
+            "type": "integer",
+            "minimum": 1,
+            "default": 100
+          },
+          "samples": {
+            "description": "How many samples of measurements for a single configuration are present in full search space file",
+            "type": "integer",
+            "minimum": 1,
+            "default": 32
+          },
+          "minimum_number_of_valid_search_iterations": {
+            "description": "How many non-error, valid configurations account for a single run of search strategy",
+            "type": "integer",
+            "minimum": 1,
+            "default": 20
+          },
+          "ignore_cache": {
+            "description": "If true, always re-run the experiments, even though results from previously executed experiments are stored in run folder.",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    },
+    "statistics_settings": {
+      "description": "Settings for the statistics calculation",
+      "type": "object",
+      "required": [
+        "minimization",
+        "cutoff_percentile",
+        "cutoff_percentile_start",
+        "cutoff_type",
+        "objective_time_keys",
+        "objective_performance_keys"      
+      ],
+      "properties": {
+        "minimization": {
+          "description": "Whether the optimization aims to minimize or maximize",
+          "type": "boolean",
+          "default": true
+        },
+        "cutoff_percentile": {
+          "description": "Fraction of difference between median and absolute optimum at which to stop the time range",
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 1
+        },
+        "cutoff_percentile_start": {
+          "description": "Fraction of difference between median and absolute optimum at which to start the time range",
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMaximum": 1
+        },
+        "cutoff_type": {
+          "description": "Whether to base the cutoff on function evaluations or time",
+          "type": "string",
+          "enum": [
+            "fevals",
+            "time"
+          ]
+        },
+        "objective_time_keys": {
+          "description": "Time key(s) to use as the time objective. In case of multiple keys, the values are summed.",
+          "type": "array",
+          "items": {
+            "enum": [
+              "compilation_time",
+              "runtimes",
+              "framework",
+              "search_algorithm",
+              "validation",
+              "all"
+            ]
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        },
+        "objective_performance_keys": {
+          "description": "The performance key(s) to use as the performance objective. In case of multiple keys, the values are summed.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      } 
+    },
+    "visualization_settings": {
+      "description": "Settings for the visualizations",
+      "type": "object",
+      "required": [
+        "resolution",
+        "x_axis_value_types",
+        "y_axis_value_types",
+        "confidence_level"
+      ],
+      "properties": {
+        "resolution": {
+          "description": "The resolution of the time range",
+          "type": "integer",
+          "minimum": 2
+        },
+        "x_axis_value_types": {
+          "description": "Types of value on the x-axis. Multiple values produces multiple (sub) plots.",
           "type": "array",
           "items": {
             "type": "string",
@@ -95,8 +302,8 @@
           "minItems": 1,
           "uniqueItems": true
         },
-        "plot_y_value_types": {
-          "description": "Types of value on the y-axis (absolute values, median-absolute normalized, improvement over baseline)",
+        "y_axis_value_types": {
+          "description": "Types of value on the y-axis. Multiple values produces multiple (sub) plots.",
           "type": "array",
           "items": {
             "type": "string",
@@ -111,43 +318,23 @@
           "uniqueItems": true
         },
         "confidence_level": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "description": "The confidence level used for the confidence / prediction interval, visualized as an error shade",
+          "type": "number", 
+          "default": 0.95,
           "exclusiveMinimum": 0,
           "maximum": 1
         },
         "compare_baselines": {
+          "description": "[preview feature] Compare baselines to each other. Requires editing the baselines list in the `plot_baselines_comparison` function.",
           "type": "boolean",
           "default": false
         },
         "compare_split_times": {
+          "description": "[preview feature] Plot a comparison of split times for strategies and baselines",
           "type": "boolean",
           "default": false
         }
-      },
-      "required": [
-        "plot_x_value_types",
-        "plot_y_value_types",
-        "confidence_level"
-      ]
+      }
     }
-  },
-  "required": [
-    "version",
-    "name",
-    "folder_id",
-    "kernels_path",
-    "bruteforced_caches_path",
-    "visualization_caches_path",
-    "kernels",
-    "GPUs",
-    "minimization",
-    "resolution",
-    "cutoff_percentile",
-    "cutoff_percentile_start",
-    "cutoff_type",
-    "plot"
-  ]
+  }
 }


### PR DESCRIPTION
Hi,
based on our discussions, I have implemented the following:
- change the schema of the experiment setup json file
- support one input json file per experimental group
	- user-provided input json file for each application
	- list of applications and GPUs
	- within the package, an input json file is created for each experimental group (combination of application, GPU and search strategy) and then loaded and executed by the autotuner
- autotuners KernelTuner and KTT supported
	- we allow to use your own complied executables/libraries of autotuners
	- but provide abstraction to default (current version) of autotuners, this goes only for KT currently, KTT needs to be built by the user
-  predetermined directory structure that separates setup files and output files
	- and makes it possible to run the experiments on a cluster and do the visualization part on local computer

Known TODOs:
- get it working with KernelTuner. I'm not sure whether KT already supports input json as a single input for run.
- fix visualization part even for KTT. autotuning_experiment finishes fine for all three examples (experiment_files/ktt_*.json), visualization gets stuck on the same error for all three of those. 
- modify and add tests

I have tried to follow at least some of the contributing guidelines (I think the formatting should be more or less fine and I'm sending you my notes and draft of user guide). I'm sorry to leave this project in this state, ideally I'd like to give it one or two more months to have it more tested and polished for production, but alas, life has its own time frames and I really can't postpone this one :)